### PR TITLE
홈 화면, 내물물교환화면 수정

### DIFF
--- a/lib/src/models/exchange/exchange_dto_model.dart
+++ b/lib/src/models/exchange/exchange_dto_model.dart
@@ -1,0 +1,175 @@
+import 'package:navada_mobile_app/src/models/product/product_model.dart';
+
+class ExchangeDtoPageResponse {
+  bool? success;
+  int? code;
+  String? message;
+  List<ExchangeDtoModel>? content;
+  Pageable? pageable;
+  int? totalPages;
+  int? totalElements;
+  bool? empty;
+  bool? first;
+  bool? last;
+  int? numberOfElements;
+  int? size;
+
+  ExchangeDtoPageResponse(
+      {this.success,
+      this.code,
+      this.message,
+      this.content,
+      this.pageable,
+      this.totalPages,
+      this.totalElements,
+      this.empty,
+      this.first,
+      this.last,
+      this.numberOfElements,
+      this.size});
+
+  ExchangeDtoPageResponse.fromJson(Map<String, dynamic> json) {
+    success = json['success'];
+    code = json['code'];
+    message = json['message'];
+    if (json['content'] != null) {
+      content = <ExchangeDtoModel>[];
+      json['content'].forEach((v) {
+        content!.add(ExchangeDtoModel.fromJson(v));
+      });
+    }
+    pageable = json['pageable'] != null
+        ? Pageable.fromJson(json['pageable'])
+        : null;
+    totalPages = json['totalPages'];
+    totalElements = json['totalElements'];
+    empty = json['empty'];
+    first = json['first'];
+    last = json['last'];
+    numberOfElements = json['numberOfElements'];
+    size = json['size'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['success'] = success;
+    data['code'] = code;
+    data['message'] = message;
+    if (content != null) {
+      data['content'] = content!.map((v) => v.toJson()).toList();
+    }
+    if (pageable != null) {
+      data['pageable'] = pageable!.toJson();
+    }
+    data['totalPages'] = totalPages;
+    data['totalElements'] = totalElements;
+    data['empty'] = empty;
+    data['first'] = first;
+    data['last'] = last;
+    data['numberOfElements'] = numberOfElements;
+    data['size'] = size;
+    return data;
+  }
+}
+
+class ExchangeDtoModel {
+  int? exchangeId;
+  int? requesterId;
+  int? acceptorId;
+  ProductModel? acceptorProduct;
+  ProductModel? requesterProduct;
+
+  ExchangeDtoModel(
+      {this.exchangeId,
+      this.requesterId,
+      this.acceptorId,
+      this.acceptorProduct,
+      this.requesterProduct});
+
+  ExchangeDtoModel.fromJson(Map<String, dynamic> json) {
+    exchangeId = json['exchangeId'];
+    requesterId = json['requesterId'];
+    acceptorId = json['acceptorId'];
+    acceptorProduct = json['acceptorProduct'] != null
+        ? ProductModel.fromJson(json['acceptorProduct'])
+        : null;
+    requesterProduct = json['requesterProduct'] != null
+        ? ProductModel.fromJson(json['requesterProduct'])
+        : null;
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['exchangeId'] = exchangeId;
+    data['requesterId'] = requesterId;
+    data['acceptorId'] = acceptorId;
+    if (acceptorProduct != null) {
+      data['acceptorProduct'] = acceptorProduct!.toJson();
+    }
+    if (requesterProduct != null) {
+      data['requesterProduct'] = requesterProduct!.toJson();
+    }
+    return data;
+  }
+}
+
+class Pageable {
+  Sort? sort;
+  int? offset;
+  int? pageSize;
+  int? pageNumber;
+  bool? paged;
+  bool? unpaged;
+
+  Pageable(
+      {this.sort,
+      this.offset,
+      this.pageSize,
+      this.pageNumber,
+      this.paged,
+      this.unpaged});
+
+  Pageable.fromJson(Map<String, dynamic> json) {
+    sort = json['sort'] != null ? Sort.fromJson(json['sort']) : null;
+    offset = json['offset'];
+    pageSize = json['pageSize'];
+    pageNumber = json['pageNumber'];
+    paged = json['paged'];
+    unpaged = json['unpaged'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    if (sort != null) {
+      data['sort'] = sort!.toJson();
+    }
+    data['offset'] = offset;
+    data['pageSize'] = pageSize;
+    data['pageNumber'] = pageNumber;
+    data['paged'] = paged;
+    data['unpaged'] = unpaged;
+    return data;
+  }
+}
+
+class Sort {
+  bool? empty;
+  bool? unsorted;
+  bool? sorted;
+
+  Sort({this.empty, this.unsorted, this.sorted});
+
+  Sort.fromJson(Map<String, dynamic> json) {
+    empty = json['empty'];
+    unsorted = json['unsorted'];
+    sorted = json['sorted'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['empty'] = empty;
+    data['unsorted'] = unsorted;
+    data['sorted'] = sorted;
+    return data;
+  }
+}

--- a/lib/src/models/exchange/exchange_service.dart
+++ b/lib/src/models/exchange/exchange_service.dart
@@ -18,6 +18,32 @@ class ExchangeService {
     }
   }
 
+  // 교환중/교환완료인 교환 조회(내가 신청한것만 보기)
+  Future<ExchangeDtoPageResponse?> getExchangeListViewOnlySent(int userId, int pageNum) async {
+    Map<String, dynamic> data = await _httpClient.getRequest(
+        '/user/$userId/exchanges?viewOnlySentElseGot=true&page=$pageNum',
+        tokenYn: false);
+
+    if (data['success']) {
+      return ExchangeDtoPageResponse.fromJson(data);
+    } else {
+      return null;
+    }
+  }
+
+  // 교환중/교환완료인 교환 조회(신청받은것만 보기)
+  Future<ExchangeDtoPageResponse?> getExchangeListViewOnlyGot(int userId, int pageNum) async {
+    Map<String, dynamic> data = await _httpClient.getRequest(
+        '/user/$userId/exchanges?viewOnlySentElseGot=false&page=$pageNum',
+        tokenYn: false);
+
+    if (data['success']) {
+      return ExchangeDtoPageResponse.fromJson(data);
+    } else {
+      return null;
+    }
+  }
+
   // 교환완료내역 삭제
   Future<ExchangeModel?> deleteCompletedExchange(int exchangeId, bool isAcceptor) async {
     Map<String, dynamic> data = await _httpClient.patchRequest(

--- a/lib/src/models/exchange/exchange_service.dart
+++ b/lib/src/models/exchange/exchange_service.dart
@@ -1,17 +1,33 @@
 import 'package:navada_mobile_app/src/models/api/http_client.dart';
 import 'package:navada_mobile_app/src/models/exchange/exchange_dto_model.dart';
+import 'package:navada_mobile_app/src/models/exchange/exchange_model.dart';
 
 HttpClient _httpClient = HttpClient();
 
-// 교환중/교환완료인 교환 조회
-Future<ExchangeDtoPageResponse?> getExchangeList(int userId, int pageNum) async {
-  Map<String, dynamic> data = await _httpClient.getRequest(
-      '/user/$userId/exchanges?page=$pageNum',
-      tokenYn: false);
+class ExchangeService {
+  // 교환중/교환완료인 교환 조회
+  Future<ExchangeDtoPageResponse?> getExchangeList(int userId, int pageNum) async {
+    Map<String, dynamic> data = await _httpClient.getRequest(
+        '/user/$userId/exchanges?page=$pageNum',
+        tokenYn: false);
 
-  if (data['success']) {
-    return ExchangeDtoPageResponse.fromJson(data);
-  } else {
-    return null;
+    if (data['success']) {
+      return ExchangeDtoPageResponse.fromJson(data);
+    } else {
+      return null;
+    }
+  }
+
+  // 교환완료내역 삭제
+  Future<ExchangeModel?> deleteCompletedExchange(int exchangeId, bool isAcceptor) async {
+    Map<String, dynamic> data = await _httpClient.patchRequest(
+        '/exchange/$exchangeId/delete?isAcceptor=$isAcceptor', {}, tokenYn: false);
+
+    if (data['success']) {
+      return ExchangeModel.fromJson(data['data']);
+    } else {
+      return null;
+    }
   }
 }
+

--- a/lib/src/models/exchange/exchange_service.dart
+++ b/lib/src/models/exchange/exchange_service.dart
@@ -1,16 +1,16 @@
 import 'package:navada_mobile_app/src/models/api/http_client.dart';
-import 'package:navada_mobile_app/src/models/exchange/exchange_model.dart';
+import 'package:navada_mobile_app/src/models/exchange/exchange_dto_model.dart';
 
 HttpClient _httpClient = HttpClient();
 
 // 교환중/교환완료인 교환 조회
-Future<ExchangePageResponse?> getExchangeList(int userId, int pageNum) async {
+Future<ExchangeDtoPageResponse?> getExchangeList(int userId, int pageNum) async {
   Map<String, dynamic> data = await _httpClient.getRequest(
       '/user/$userId/exchanges?page=$pageNum',
       tokenYn: false);
 
   if (data['success']) {
-    return ExchangePageResponse.fromJson(data);
+    return ExchangeDtoPageResponse.fromJson(data);
   } else {
     return null;
   }

--- a/lib/src/models/request/request_service.dart
+++ b/lib/src/models/request/request_service.dart
@@ -71,4 +71,28 @@ class RequestService {
       throw Exception('교환신청취소 실패');
     }
   }
+
+  // 거절한 신청내역 삭제
+  Future<RequestModel?> deleteDeniedRequestByAcceptor(int requestId) async {
+    Map<String, dynamic> data = await _httpClient.patchRequest(
+        '/exchange/request/$requestId/delete?isAcceptor=true', {}, tokenYn: false);
+
+    if (data['success']) {
+      return RequestModel.fromJson(data['data']);
+    } else {
+      return null;
+    }
+  }
+
+  // 거절당한 신청내역 삭제
+  Future<RequestModel?> deleteDeniedRequestByRequester(int requestId) async {
+    Map<String, dynamic> data = await _httpClient.patchRequest(
+        '/exchange/request/$requestId/delete?isAcceptor=false', {}, tokenYn: false);
+
+    if (data['success']) {
+      return RequestModel.fromJson(data['data']);
+    } else {
+      return null;
+    }
+  }
 }

--- a/lib/src/providers/home_requests_provider.dart
+++ b/lib/src/providers/home_requests_provider.dart
@@ -104,4 +104,10 @@ class RequestsForMeProvider extends ChangeNotifier {
     _dataState = DataState.ERROR;
     notifyListeners();
   }
+
+  deleteDeniedRequest(int? requestId) async {
+    await _requestService.deleteDeniedRequestByAcceptor(requestId!);
+    _requestDataList.removeWhere((request) => request.requestId == requestId);
+    notifyListeners();
+  }
 }

--- a/lib/src/providers/my_exchanges_exchange_provider.dart
+++ b/lib/src/providers/my_exchanges_exchange_provider.dart
@@ -1,8 +1,10 @@
 // ignore_for_file: curly_braces_in_flow_control_structures
 
+
 import 'package:flutter/material.dart';
 import 'package:navada_mobile_app/src/models/exchange/exchange_dto_model.dart';
 import 'package:navada_mobile_app/src/models/exchange/exchange_service.dart';
+import 'package:navada_mobile_app/src/screens/my_exchange/my_exchanges_view_model.dart';
 import 'package:navada_mobile_app/src/utilities/enums.dart';
 
 class MyExchangesExchangeProvider extends ChangeNotifier {
@@ -13,6 +15,7 @@ class MyExchangesExchangeProvider extends ChangeNotifier {
   final ExchangeService _exchangeService = ExchangeService();
 
   int _currentPageNum = 0;
+  MyExchangesFilterItem _curFilter = MyExchangesFilterItem.viewAll;
   DataState _dataState = DataState.UNINITIALIZED;
   List<ExchangeDtoModel> _exchangeDataList = [];
   late int _totalPages;
@@ -25,6 +28,12 @@ class MyExchangesExchangeProvider extends ChangeNotifier {
   bool get _isInitialFetching => _dataState == DataState.INITIAL_FETCHING;
   bool get _isRefreshing => _dataState == DataState.REFRESHING;
   bool get _shouldResetTotalPagesAndTotalElements => _isInitialFetching || _dataState == DataState.REFRESHING;
+
+  setFilter(MyExchangesFilterItem newFilter) {
+    _curFilter = newFilter;
+    notifyListeners();
+    fetchData(isRefresh: true);
+  }
 
   fetchData({bool isRefresh = false}) async {
     if(isRefresh)
@@ -80,8 +89,14 @@ class MyExchangesExchangeProvider extends ChangeNotifier {
   }
 
   _getPageResponse() async {
-    ExchangeDtoPageResponse? pageResponse = await _exchangeService.getExchangeList(_userId, _currentPageNum);
-
+    ExchangeDtoPageResponse? pageResponse;
+    if(_curFilter == MyExchangesFilterItem.viewAll) {
+      pageResponse = await _exchangeService.getExchangeList(_userId, _currentPageNum);
+    } else if(_curFilter == MyExchangesFilterItem.viewOnlyISent) {
+      pageResponse = await _exchangeService.getExchangeListViewOnlySent(_userId, _currentPageNum);
+    } else {
+      pageResponse = await _exchangeService.getExchangeListViewOnlyGot(_userId, _currentPageNum);
+    }
     await _resetTotalPagesAndTotalElements(pageResponse!.totalPages!, pageResponse.totalElements!);
 
     return pageResponse;

--- a/lib/src/providers/my_exchanges_exchange_provider.dart
+++ b/lib/src/providers/my_exchanges_exchange_provider.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: curly_braces_in_flow_control_structures
 
 import 'package:flutter/material.dart';
-import 'package:navada_mobile_app/src/models/exchange/exchange_model.dart';
+import 'package:navada_mobile_app/src/models/exchange/exchange_dto_model.dart';
 import 'package:navada_mobile_app/src/models/exchange/exchange_service.dart';
 import 'package:navada_mobile_app/src/utilities/enums.dart';
 
@@ -12,14 +12,14 @@ class MyExchangesExchangeProvider extends ChangeNotifier {
 
   int _currentPageNum = 0;
   DataState _dataState = DataState.UNINITIALIZED;
-  List<ExchangeModel> _exchangeDataList = [];
+  List<ExchangeDtoModel> _exchangeDataList = [];
   late int _totalPages;
   late int _totalElements = 0;
   
   bool get hasData => _isRefreshing || _exchangeDataList.isNotEmpty;
   DataState get dataState => _dataState;
   int get totalElements => _totalElements;
-  List<ExchangeModel> get exchangeDataList => _exchangeDataList;
+  List<ExchangeDtoModel> get exchangeDataList => _exchangeDataList;
   bool get _isInitialFetching => _dataState == DataState.INITIAL_FETCHING;
   bool get _isRefreshing => _dataState == DataState.REFRESHING;
   bool get _shouldResetTotalPagesAndTotalElements => _isInitialFetching || _dataState == DataState.REFRESHING;
@@ -69,8 +69,8 @@ class MyExchangesExchangeProvider extends ChangeNotifier {
   }
 
   _fetchData() async {
-    ExchangePageResponse? pageResponse = await _getPageResponse();
-    List<ExchangeModel>? newExchanges = pageResponse!.content;
+    ExchangeDtoPageResponse? pageResponse = await _getPageResponse();
+    List<ExchangeDtoModel>? newExchanges = pageResponse!.content;
 
     _exchangeDataList += newExchanges!;
     _currentPageNum += 1;
@@ -78,7 +78,7 @@ class MyExchangesExchangeProvider extends ChangeNotifier {
   }
 
   _getPageResponse() async {
-    ExchangePageResponse? pageResponse = await getExchangeList(_userId, _currentPageNum);
+    ExchangeDtoPageResponse? pageResponse = await getExchangeList(_userId, _currentPageNum);
 
     await _resetTotalPagesAndTotalElements(pageResponse!.totalPages!, pageResponse.totalElements!);
 

--- a/lib/src/providers/my_exchanges_exchange_provider.dart
+++ b/lib/src/providers/my_exchanges_exchange_provider.dart
@@ -10,6 +10,8 @@ class MyExchangesExchangeProvider extends ChangeNotifier {
 
   final int _userId;
 
+  final ExchangeService _exchangeService = ExchangeService();
+
   int _currentPageNum = 0;
   DataState _dataState = DataState.UNINITIALIZED;
   List<ExchangeDtoModel> _exchangeDataList = [];
@@ -78,7 +80,7 @@ class MyExchangesExchangeProvider extends ChangeNotifier {
   }
 
   _getPageResponse() async {
-    ExchangeDtoPageResponse? pageResponse = await getExchangeList(_userId, _currentPageNum);
+    ExchangeDtoPageResponse? pageResponse = await _exchangeService.getExchangeList(_userId, _currentPageNum);
 
     await _resetTotalPagesAndTotalElements(pageResponse!.totalPages!, pageResponse.totalElements!);
 
@@ -94,5 +96,11 @@ class MyExchangesExchangeProvider extends ChangeNotifier {
   _handleError() {
     _dataState = DataState.ERROR;
     notifyListeners();
+  }
+
+  deleteCompletedExchange(int? exchangeId, int? acceptorId) async {
+    bool isAcceptor = (_userId == acceptorId);
+    await _exchangeService.deleteCompletedExchange(exchangeId!, isAcceptor);
+    _exchangeDataList.removeWhere((exchange) => exchange.exchangeId == exchangeId);
   }
 }

--- a/lib/src/providers/my_exchanges_request_provider.dart
+++ b/lib/src/providers/my_exchanges_request_provider.dart
@@ -99,8 +99,14 @@ class MyExchangesRequestProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  deleteRequest(int requestId) async {
+  cancelRequest(int requestId) async {
     await _requestService.deleteRequest(requestId);
+    _requestDataList.removeWhere((request) => request.requestId == requestId);
+    notifyListeners();
+  }
+
+  deleteDeniedRequest(int requestId) async {
+    await _requestService.deleteDeniedRequestByRequester(requestId);
     _requestDataList.removeWhere((request) => request.requestId == requestId);
     notifyListeners();
   }

--- a/lib/src/screens/home/home_requests_widget.dart
+++ b/lib/src/screens/home/home_requests_widget.dart
@@ -187,13 +187,16 @@ class _RequestsForMeGridView extends StatelessWidget {
   }
 }
 
+// ignore: must_be_immutable
 class RequestItem extends StatelessWidget {
-  const RequestItem({Key? key, this.request}) : super(key: key);
+  RequestItem({Key? key, this.request}) : super(key: key);
 
   final RequestModel? request;
+  late BuildContext? _context;
 
   @override
   Widget build(BuildContext context) {
+    _context = context;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -245,7 +248,13 @@ class RequestItem extends StatelessWidget {
           const Space(height: 2),
           _priceInfo(),
           const Space(height: 4),
-          _costRangeInfo(),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+            _costRangeInfo(),
+            if (request!.exchangeStatusCd == ExchangeStatusCd.DENIED)
+              _deleteDeniedRequestBtn(),
+          ],)
         ],
       ),
     );
@@ -273,5 +282,30 @@ class RequestItem extends StatelessWidget {
 
   _costRangeInfo() {
     return CostRangeBadge(cost: request!.requesterProductCostRange);
+  }
+
+  _deleteDeniedRequestBtn() {
+    ScreenSize size = ScreenSize();
+    return PopupMenuButton(
+      constraints: BoxConstraints(maxWidth: size.getSize(60)),
+      padding: const EdgeInsets.all(0),
+      offset: const Offset(0, -25),
+      elevation: 10.0,
+      position: PopupMenuPosition.over,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(size.getSize(5))),
+      ),
+      itemBuilder: (context) => [
+        PopupMenuItem(
+          onTap: () {
+            Provider.of<RequestsForMeProvider>(_context!, listen: false).deleteDeniedRequest(request?.requestId);
+          },
+          height: size.getSize(24),
+          value: '삭제',
+          child: SizedBox(width: size.getSize(30), child: const R14Text(text: '삭제')),
+        )
+      ],
+      child: Icon(Icons.more_vert, size: size.getSize(18), color: Colors.grey,)
+    );
   }
 }

--- a/lib/src/screens/my_exchange/my_exchanges_view_model.dart
+++ b/lib/src/screens/my_exchange/my_exchanges_view_model.dart
@@ -13,7 +13,7 @@ class MyExchangesViewModel extends ChangeNotifier {
 
 enum MyExchangesFilterItem { 
   viewAll('전체보기'), 
-  viewOnlyIApplied('내가 신청한것만 보기'), 
+  viewOnlyISent('내가 신청한것만 보기'), 
   viewOnlyIGot('신청받은것만 보기');
 
   const MyExchangesFilterItem(this.label);

--- a/lib/src/screens/my_exchange/products_I_requested_widget.dart
+++ b/lib/src/screens/my_exchange/products_I_requested_widget.dart
@@ -105,7 +105,7 @@ class _RequestListView extends StatelessWidget {
           _totalElementsCount(),
           hasData
             ? _requestListView()
-            : const NoElements(text: '신청한 내역이 없습니다.')
+            : const Expanded(child: NoElements(text: '신청한 내역이 없습니다.'))
         ]),
     );
   }

--- a/lib/src/screens/my_exchange/products_I_requested_widget.dart
+++ b/lib/src/screens/my_exchange/products_I_requested_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:navada_mobile_app/src/models/request/request_model.dart';
 import 'package:navada_mobile_app/src/providers/my_exchanges_request_provider.dart';
 import 'package:navada_mobile_app/src/utilities/enums.dart';
+import 'package:navada_mobile_app/src/utilities/shortener.dart';
 import 'package:navada_mobile_app/src/widgets/colors.dart';
 import 'package:navada_mobile_app/src/widgets/my_exchange_card.dart';
 import 'package:navada_mobile_app/src/widgets/my_exchange_status_sign.dart';
@@ -207,11 +208,15 @@ class RequestItem extends StatelessWidget {
         : const MyExchangeStatusSign(color: grey216, icon: Icons.not_interested, label: '거절됨'),
       params: MyExchangeCardParams(
         requesterProductName: request?.requesterProductName,
-        requesterNickname: request?.requesterNickName,
+        requesterNickname: Row(children: [
+                  B10Text(text: "신청 ", textColor: isWait ? yellow : grey153),
+                  R10Text(text: Shortener.shortenStrTo(request?.requesterNickName, 6), textColor: grey183),]),
         requesterProductCost: request?.requesterProductCost,
         requesterProductCostRange: request?.requesterProductCostRange,
         acceptorProductName: request?.acceptorProductName,
-        acceptorNickname: request?.acceptorNickname,
+        acceptorNickname: Row(children: [
+                  B10Text(text: isWait ? "대기 " : "거절 ", textColor: isWait ? yellow : grey153),
+                  R10Text(text: Shortener.shortenStrTo(request?.acceptorNickname, 6), textColor: grey183),]),
         acceptorProductCost: request?.acceptorProductCost,
         acceptorProductCostRange: request?.acceptorProductCostRange
       ),

--- a/lib/src/screens/my_exchange/products_I_requested_widget.dart
+++ b/lib/src/screens/my_exchange/products_I_requested_widget.dart
@@ -111,8 +111,6 @@ class _RequestListView extends StatelessWidget {
   }
 
   Widget _requestListView() {
-    ScreenSize size = ScreenSize();
-
     return Expanded(
       child: ListView.separated(
         padding: const EdgeInsets.all(0.0),
@@ -120,51 +118,58 @@ class _RequestListView extends StatelessWidget {
         itemCount: requestList.length,
         itemBuilder: (context, index) {
           final request = requestList[index];
-          bool isWait = request.exchangeStatusCd == ExchangeStatusCd.WAIT;
-    
-          return Dismissible(
-            key: UniqueKey(),
-            onDismissed: (direction) {
-              if(isWait) {
-                Provider.of<MyExchangesRequestProvider>(_context!, listen: false).deleteRequest(request.requestId!);
-              }
-            },
-            confirmDismiss: (direction) async {
-                return await showDialog(
-                  context: context,
-                  builder: (BuildContext context) {
-                    return AlertDialog(
-                      content: R14Text(text: isWait ? "교환신청을 정말로 취소하시겠습니까?" : "거절내역을 삭제하시겠습니까?"),
-                      actions: <Widget>[
-                        TextButton(
-                          onPressed: () => Navigator.of(context).pop(false),
-                          child: const R14Text(text: "아니요", textColor: grey153),
-                        ),
-                        TextButton(
-                          onPressed: () => Navigator.of(context).pop(true),
-                          child: R14Text(text: isWait ? "네, 취소할게요!" : "네, 삭제할게요!", textColor: blue),
-                        ),
-                      ],
-                    );
-                  }
-                );
-            },
-            direction: DismissDirection.endToStart,
-            background: Container(
-                decoration: BoxDecoration(
-                    color: grey183,
-                    borderRadius: BorderRadius.circular(size.getSize(10))),
-                padding: EdgeInsets.only(right: size.getSize(20)),
-                child: Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: const [Icon(Icons.delete, color: white)])
-            ),
-            child: RequestItem(request: request),
-          );
+          return _dismissibleListItem(context, request);
         },
         separatorBuilder: (context, index) {
           return const Space(height: 10);
         }),
+    );
+  }
+
+  _dismissibleListItem(BuildContext? context, RequestModel request) {
+    ScreenSize size = ScreenSize();
+    bool isWait = request.exchangeStatusCd == ExchangeStatusCd.WAIT;
+    
+    return Dismissible(
+      key: UniqueKey(),
+      onDismissed: (direction) {
+        if(isWait) {
+          Provider.of<MyExchangesRequestProvider>(_context!, listen: false).cancelRequest(request.requestId!);
+        } else {
+          Provider.of<MyExchangesRequestProvider>(_context!, listen: false).deleteDeniedRequest(request.requestId!);
+        }
+      },
+      confirmDismiss: (direction) async {
+          return await showDialog(
+            context: context!,
+            builder: (BuildContext context) {
+              return AlertDialog(
+                content: R14Text(text: isWait ? "교환신청을 정말로 취소하시겠습니까?" : "거절내역을 삭제하시겠습니까?"),
+                actions: <Widget>[
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(false),
+                    child: const R14Text(text: "아니요", textColor: grey153),
+                  ),
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(true),
+                    child: R14Text(text: isWait ? "네, 취소할게요!" : "네, 삭제할게요!", textColor: blue),
+                  ),
+                ],
+              );
+            }
+          );
+      },
+      direction: DismissDirection.endToStart,
+      background: Container(
+          decoration: BoxDecoration(
+              color: isWait ? yellow : grey183,
+              borderRadius: BorderRadius.circular(size.getSize(10))),
+          padding: EdgeInsets.only(right: size.getSize(20)),
+          child: Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: const [Icon(Icons.delete, color: white)])
+      ),
+      child: RequestItem(request: request),
     );
   }
 

--- a/lib/src/screens/my_exchange/trading_and_completed_tab_widget.dart
+++ b/lib/src/screens/my_exchange/trading_and_completed_tab_widget.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:navada_mobile_app/src/models/exchange/exchange_model.dart';
+import 'package:navada_mobile_app/src/models/exchange/exchange_dto_model.dart';
 import 'package:navada_mobile_app/src/models/product/product_model.dart';
 import 'package:navada_mobile_app/src/providers/my_exchanges_exchange_provider.dart';
 import 'package:navada_mobile_app/src/screens/my_exchange/my_exchanges_view_model.dart';
@@ -55,7 +55,7 @@ class TradingAndCompletedTab extends StatelessWidget {
 class _ExchangeListView extends StatelessWidget {
   _ExchangeListView({Key? key, required this.exchangeList, required this.isLoading}) : super(key: key);
 
-  List<ExchangeModel> exchangeList;
+  List<ExchangeDtoModel> exchangeList;
   bool isLoading;
 
   late DataState? _dataState;
@@ -149,7 +149,7 @@ class _ExchangeListView extends StatelessWidget {
 class ExchangeItem extends StatelessWidget {
   const ExchangeItem({Key? key, this.exchange}) : super(key: key);
 
-  final ExchangeModel? exchange;
+  final ExchangeDtoModel? exchange;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/screens/my_exchange/trading_and_completed_tab_widget.dart
+++ b/lib/src/screens/my_exchange/trading_and_completed_tab_widget.dart
@@ -106,7 +106,7 @@ class _ExchangeListView extends StatelessWidget {
           _filterSection(),
           hasData
             ? _exchangeListView()
-            : const NoElements(text: '물물교환내역이 없습니다.')
+            : const Expanded(child: NoElements(text: '물물교환내역이 없습니다.'))
         ]),
     );
   }

--- a/lib/src/screens/my_exchange/trading_and_completed_tab_widget.dart
+++ b/lib/src/screens/my_exchange/trading_and_completed_tab_widget.dart
@@ -303,9 +303,6 @@ class _ViewFilter extends StatelessWidget {
       onTap: () async {
         Provider.of<MyExchangesViewModel>(_context!, listen: false).setFilter(selectedFilter!);
         Provider.of<MyExchangesExchangeProvider>(_context!, listen: false).setFilter(selectedFilter);
-        if(selectedFilter == MyExchangesFilterItem.viewAll) {
-          
-        }
         Navigator.of(_context!).pop(false);
       },
       child: ListTile(

--- a/lib/src/screens/my_exchange/trading_and_completed_tab_widget.dart
+++ b/lib/src/screens/my_exchange/trading_and_completed_tab_widget.dart
@@ -118,11 +118,58 @@ class _ExchangeListView extends StatelessWidget {
         shrinkWrap: true,
         itemCount: exchangeList.length,
         itemBuilder: (context, index) {
-          return ExchangeItem(exchange: exchangeList[index]);
+          ExchangeDtoModel exchange = exchangeList[index];
+          bool isTrading = exchange.acceptorProduct?.productStatusCd == ProductStatusCd.TRADING;
+
+          return (isTrading)
+            ? ExchangeItem(exchange: exchange)
+            : _dismissibleCompletedExchangeItem(context, exchange);
         },
         separatorBuilder: (context, index) {
           return const Space(height: 10);
         }),
+    );
+  }
+
+  Widget _dismissibleCompletedExchangeItem(BuildContext? context, ExchangeDtoModel? exchange) {
+    ScreenSize size = ScreenSize();
+
+    return Dismissible(
+      key: UniqueKey(),
+      onDismissed: (direction) {
+        Provider.of<MyExchangesExchangeProvider>(_context!, listen: false).deleteCompletedExchange(exchange!.exchangeId, exchange.acceptorId);
+      },
+      confirmDismiss: (direction) async {
+          return await showDialog(
+            context: context!,
+            builder: (BuildContext context) {
+              return AlertDialog(
+                content: const R14Text(text: "교환내역을 삭제하시겠습니까?"),
+                actions: <Widget>[
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(false),
+                    child: const R14Text(text: "아니요", textColor: grey153),
+                  ),
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(true),
+                    child: const R14Text(text: "네, 삭제할게요!", textColor: blue),
+                  ),
+                ],
+              );
+            }
+          );
+      },
+      direction: DismissDirection.endToStart,
+      background: Container(
+          decoration: BoxDecoration(
+              color: grey183,
+              borderRadius: BorderRadius.circular(size.getSize(10))),
+          padding: EdgeInsets.only(right: size.getSize(20)),
+          child: Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: const [Icon(Icons.delete, color: white)])
+      ),
+      child: ExchangeItem(exchange: exchange),
     );
   }
 

--- a/lib/src/screens/my_exchange/trading_and_completed_tab_widget.dart
+++ b/lib/src/screens/my_exchange/trading_and_completed_tab_widget.dart
@@ -4,6 +4,7 @@ import 'package:navada_mobile_app/src/models/product/product_model.dart';
 import 'package:navada_mobile_app/src/providers/my_exchanges_exchange_provider.dart';
 import 'package:navada_mobile_app/src/screens/my_exchange/my_exchanges_view_model.dart';
 import 'package:navada_mobile_app/src/utilities/enums.dart';
+import 'package:navada_mobile_app/src/utilities/shortener.dart';
 import 'package:navada_mobile_app/src/widgets/colors.dart';
 import 'package:navada_mobile_app/src/widgets/divider.dart';
 import 'package:navada_mobile_app/src/widgets/my_exchange_card.dart';
@@ -210,11 +211,15 @@ class ExchangeItem extends StatelessWidget {
         : const MyExchangeStatusSign(color: navy, icon: Icons.check, label: '교환완료'),
       params: MyExchangeCardParams(
         requesterProductName: requesterProduct?.productName,
-        requesterNickname: requesterProduct?.userNickname,
+        requesterNickname: Row(children: [
+                  B10Text(text: "신청 ", textColor: isTrading ? green : navy),
+                  R10Text(text: Shortener.shortenStrTo(requesterProduct?.userNickname, 6), textColor: grey183),]),
         requesterProductCost: requesterProduct?.productCost,
         requesterProductCostRange: requesterProduct?.exchangeCostRange,
         acceptorProductName: acceptorProduct?.productName,
-        acceptorNickname: acceptorProduct?.userNickname,
+        acceptorNickname: Row(children: [
+                  B10Text(text: "수락 ", textColor: isTrading ? green : navy),
+                  R10Text(text: Shortener.shortenStrTo(acceptorProduct?.userNickname, 6), textColor: grey183),]),
         acceptorProductCost: acceptorProduct?.productCost,
         acceptorProductCostRange: acceptorProduct?.exchangeCostRange
       ),
@@ -295,8 +300,11 @@ class _ViewFilter extends StatelessWidget {
   Widget _customListTile(MyExchangesFilterItem? selectedFilter) {
     ScreenSize size = ScreenSize();
     return GestureDetector(
-      onTap: () {
+      onTap: () async {
         Provider.of<MyExchangesViewModel>(_context!, listen: false).setFilter(selectedFilter!);
+        if(selectedFilter == MyExchangesFilterItem.viewAll) {
+          
+        }
         Navigator.of(_context!).pop(false);
       },
       child: ListTile(

--- a/lib/src/screens/my_exchange/trading_and_completed_tab_widget.dart
+++ b/lib/src/screens/my_exchange/trading_and_completed_tab_widget.dart
@@ -270,7 +270,7 @@ class _ViewFilter extends StatelessWidget {
           _greyStick(),
           _customListTile(MyExchangesFilterItem.viewAll),
           const CustomDivider(horizontalIndent: 18),
-          _customListTile(MyExchangesFilterItem.viewOnlyIApplied),
+          _customListTile(MyExchangesFilterItem.viewOnlyISent),
           const CustomDivider(horizontalIndent: 18),
           _customListTile(MyExchangesFilterItem.viewOnlyIGot)
         ],
@@ -302,6 +302,7 @@ class _ViewFilter extends StatelessWidget {
     return GestureDetector(
       onTap: () async {
         Provider.of<MyExchangesViewModel>(_context!, listen: false).setFilter(selectedFilter!);
+        Provider.of<MyExchangesExchangeProvider>(_context!, listen: false).setFilter(selectedFilter);
         if(selectedFilter == MyExchangesFilterItem.viewAll) {
           
         }

--- a/lib/src/widgets/my_exchange_card.dart
+++ b/lib/src/widgets/my_exchange_card.dart
@@ -33,15 +33,15 @@ class MyExchangeCard extends StatelessWidget {
         children: [
           statusSign!,
           const VerticalDivider(thickness: 1, color: grey239, indent: 0, endIndent: 0),
-          _productContent(params?.requesterProductName, params?.requesterNickname, params?.requesterProductCost, params?.requesterProductCostRange),
+          _productContent(params?.requesterProductName, params?.requesterNickname, params?.requesterProductCost, params?.requesterProductCostRange, false),
           const VerticalDivider(thickness: 1, color: grey239, indent: 3, endIndent: 3),
-          _productContent(params?.acceptorProductName, params?.acceptorNickname, params?.acceptorProductCost, params?.acceptorProductCostRange),
+          _productContent(params?.acceptorProductName, params?.acceptorNickname, params?.acceptorProductCost, params?.acceptorProductCostRange, true),
         ],
       )
     );
   }
 
-  Widget _productContent(String? productName, String? nickName, int? cost, int? costRange) {
+  Widget _productContent(String? productName, Widget? nickName, int? cost, int? costRange, bool isAcceptor) {
     ScreenSize size = ScreenSize();
 
     return SizedBox(
@@ -55,7 +55,7 @@ class MyExchangeCard extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               R12Text(text: Shortener.shortenStrTo(productName, 8)),
-              R10Text(text: Shortener.shortenStrTo(nickName, 10), textColor: grey216),
+              nickName!,
               R10Text(text: "원가 $cost원"),
               R10Text(text: "± $costRange원", textColor: grey183,)
             ],
@@ -84,11 +84,11 @@ class MyExchangeCardParams{
   const MyExchangeCardParams({this.requesterProductName, this.requesterNickname, this.requesterProductCost, this.requesterProductCostRange, this.acceptorProductName, this.acceptorNickname, this.acceptorProductCost, this.acceptorProductCostRange});
 
   final String? requesterProductName;
-  final String? requesterNickname;
+  final Widget? requesterNickname;
   final int? requesterProductCost;
   final int? requesterProductCostRange;
   final String? acceptorProductName;
-  final String? acceptorNickname;
+  final Widget? acceptorNickname;
   final int? acceptorProductCost;
   final int? acceptorProductCostRange;
 }

--- a/lib/src/widgets/no_elements_screen.dart
+++ b/lib/src/widgets/no_elements_screen.dart
@@ -11,20 +11,18 @@ class NoElements extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      child: LayoutBuilder(
-        builder: ((context, constraint) => 
-            SingleChildScrollView(
-              physics: const AlwaysScrollableScrollPhysics(),
-              child: ConstrainedBox(
-                constraints: BoxConstraints(minHeight: constraint.maxHeight, minWidth: double.infinity),
-                child: IntrinsicHeight(
-                  child: _noElementsNotice()
-                ),
+    return LayoutBuilder(
+      builder: ((context, constraint) => 
+          SingleChildScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraint.maxHeight, minWidth: double.infinity),
+              child: IntrinsicHeight(
+                child: _noElementsNotice()
               ),
-            )
-        )
-      ),
+            ),
+          )
+      )
     );
   }
 


### PR DESCRIPTION
회의때 결정된 내용으로 홈화면, 내물물교환화면을 수정했습니다.

홈 - 거절한 교환신청내역 삭제기능 추가
내물물교환 - 교환완료내역 삭제, 교환신청 취소, 교환신청 거절내역 삭제, 신청&수락 글씨 추가, 필터기능 적용

신청 & 수락 글씨를 이미지 위에 넣는 것보다 이게 나은것 같아서 일단 이렇게 넣어봤는데 더 나은 방법이 있을지 우리 생각나면 얘기해봐여~~!
<img width="921" alt="image" src="https://user-images.githubusercontent.com/51855129/189351611-f2f0a74b-7d70-4f12-830d-8e3679cb47e9.png">
