### PR TITLE
계정 정보 수정 닉네임 중복 확인 추가

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -20,7 +20,7 @@ PODS:
     - AppAuth/Core (~> 1.6)
     - GTMSessionFetcher/Core (< 3.0, >= 1.5)
   - GTMSessionFetcher/Core (2.3.0)
-  - kakao_flutter_sdk_common (1.3.0):
+  - kakao_flutter_sdk_common (1.3.1):
     - Flutter
   - naveridlogin-sdk-ios (4.1.5)
   - "permission_handler (5.1.0+2)":
@@ -66,7 +66,7 @@ SPEC CHECKSUMS:
   GoogleSignIn: 5651ce3a61e56ca864160e79b484cd9ed3f49b7a
   GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
   GTMSessionFetcher: 3a63d75eecd6aa32c2fc79f578064e1214dfdec2
-  kakao_flutter_sdk_common: 7c3acd2fbfe34788f69b6e97b8e47e89ebf5f4bc
+  kakao_flutter_sdk_common: b1f30bb70b2341db4d9bbad727f8356e64729668
   naveridlogin-sdk-ios: 4351fe7162cd6b8b6dbb37bd7cc205304fa1d889
   permission_handler: ccb20a9fad0ee9b1314a52b70b76b473c5f8dab0
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -242,6 +242,7 @@
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -256,6 +257,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/lib/src/models/user/user_provider.dart
+++ b/lib/src/models/user/user_provider.dart
@@ -67,6 +67,10 @@ class UserProvider extends ChangeNotifier {
     }
   }
 
+  Future<bool> checkNicknameUsable(String nickname) async {
+    return await _userService.checkNicknameUsable(nickname);
+  }
+
   // ======= 알림 확인 여부
   bool? _userNotiReadYn;
   bool? get userNotiReadYn => _userNotiReadYn;

--- a/lib/src/models/user/user_provider.dart
+++ b/lib/src/models/user/user_provider.dart
@@ -21,6 +21,8 @@ class UserProvider extends ChangeNotifier {
   }
 
   void setUserInfo(UserDto params) {
+    String phoneNum = params.userPhoneNum;
+
     user.userId = params.userId;
     user.userName = params.userName;
     user.userNickname = params.userNickname;
@@ -29,7 +31,8 @@ class UserProvider extends ChangeNotifier {
     user.userRating = params.userRating;
     user.userTradeCount = params.userTradeCount;
     user.userRatingCount = params.userRatingCount;
-    user.userPhoneNum = params.userPhoneNum;
+    user.userPhoneNum 
+      = '${phoneNum.substring(0,3)}-${phoneNum.substring(3,7)}-${phoneNum.substring(8, phoneNum.length)}';
     notifyListeners();
   }
 

--- a/lib/src/providers/signin_provider.dart
+++ b/lib/src/providers/signin_provider.dart
@@ -61,10 +61,6 @@ class SignInProvider with ChangeNotifier {
     return KakaoUserInfo(email, nickname);
   }
 
-  Future<bool> checkNicknameUsable(String nickname) async {
-    return await userService.checkNicknameUsable(nickname);
-  }
-
   Future<SignInResponse> signInByOAuth(String email, SignInPlatform platform) async {
     return await userService.signInByOAuth(email, platform);
   }

--- a/lib/src/screens/signin/signup.dart
+++ b/lib/src/screens/signin/signup.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:navada_mobile_app/src/models/user/user_provider.dart';
-import 'package:navada_mobile_app/src/providers/signin_provider.dart';
 import 'package:navada_mobile_app/src/screens/signIn/signIn.dart';
 import 'package:navada_mobile_app/src/widgets/colors.dart';
 import 'package:navada_mobile_app/src/widgets/custom_appbar.dart';
@@ -21,7 +20,7 @@ class _SignUpState extends State<SignUp> {
   ScreenSize size = ScreenSize();
   String userName="", userNickname="", userPhoneNum="", userAddress="";
 
-  bool isNicknameDuplicationCheckDone = false;
+  bool isNicknameAvailable = false;
   final FocusNode _nameFNode = FocusNode();
   final FocusNode _nicknameFNode = FocusNode();
   final FocusNode _phoneNumFNode = FocusNode();
@@ -99,7 +98,7 @@ class _SignUpState extends State<SignUp> {
             onChanged: (value) {
               setState(() { 
                 userNickname = value; 
-                isNicknameDuplicationCheckDone = false;
+                isNicknameAvailable = false;
               });
             },
             decoration: InputDecoration(
@@ -118,9 +117,9 @@ class _SignUpState extends State<SignUp> {
             if (!_checkValid(userNickname)) {
               _checkField(_nicknameFNode, "닉네임을 입력해주세요!");
             } else {
-              bool result = await Provider.of<SignInProvider>(context, listen: false).checkNicknameUsable(userNickname);
+              bool result = await Provider.of<UserProvider>(context, listen: false).checkNicknameUsable(userNickname);
               if (result) {
-                setState(() { isNicknameDuplicationCheckDone = true; });
+                setState(() { isNicknameAvailable = true; });
               } else {
                 _checkField(_nicknameFNode, "다른 닉네임을 사용해주세요!");
               }
@@ -132,12 +131,12 @@ class _SignUpState extends State<SignUp> {
             height: size.getSize(36),
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(5),
-              color: isNicknameDuplicationCheckDone ? green : white,
+              color: isNicknameAvailable ? green : white,
               border: Border.all(color: green, width: 2)
             ),
             child: R16Text(
-              text: isNicknameDuplicationCheckDone ? "확인 완료" : "중복 확인",
-              textColor: isNicknameDuplicationCheckDone ? white : green)
+              text: isNicknameAvailable ? "확인 완료" : "중복 확인",
+              textColor: isNicknameAvailable ? white : green)
           ),
         )
       ],
@@ -187,7 +186,7 @@ class _SignUpState extends State<SignUp> {
   handleSignUp() async {
     if (!_checkValid(userName)) {
       _checkField(_nameFNode, "이름을 입력해주세요!");
-    } else if (!isNicknameDuplicationCheckDone) {
+    } else if (!isNicknameAvailable) {
       _checkField(_nicknameFNode, "닉네임 중복확인을 해주세요!");
     } else if (!_checkValid(userPhoneNum)) {
       _checkField(_phoneNumFNode, "핸드폰 번호를 입력해주세요!");

--- a/lib/src/screens/tab5_mypage/account_management/setting_user_info/modify_user_info_view.dart
+++ b/lib/src/screens/tab5_mypage/account_management/setting_user_info/modify_user_info_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:navada_mobile_app/src/models/user/user_model.dart';
 import 'package:navada_mobile_app/src/models/user/user_provider.dart';
+import 'package:navada_mobile_app/src/screens/tab5_mypage/account_management/setting_user_info/modify_user_info_view_model.dart';
 import 'package:navada_mobile_app/src/widgets/colors.dart';
 import 'package:navada_mobile_app/src/widgets/custom_appbar.dart';
 import 'package:navada_mobile_app/src/widgets/long_circled_btn.dart';
@@ -18,6 +19,8 @@ class ModifyUserInfoView extends StatelessWidget {
   final TextEditingController _addressController =
       TextEditingController(text: UserProvider.user.userAddress);
 
+  late BuildContext _context;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -26,19 +29,25 @@ class ModifyUserInfoView extends StatelessWidget {
         leadingYn: true,
         onTap: () => Navigator.pop(context),
       ),
-      body: Container(
-        margin: const EdgeInsets.only(left: 20.0, right: 20.0, bottom: 20.0),
-        child: GestureDetector(
-          onTap: () => FocusScope.of(context).unfocus(),
-          child: SingleChildScrollView(
-            physics: const AlwaysScrollableScrollPhysics(),
-            child: Column(children: [
-              _userInfoSection(),
-              const Space(height: 200.0),
-              _modifyButton(context)
-            ]),
-          ),
-        ),
+      body: ChangeNotifierProvider(
+        create: (context) => ModifyUserInfoViewModel(),
+        builder: (context, child) {
+          _context = context;
+          return Container(
+            margin: const EdgeInsets.only(left: 20.0, right: 20.0, bottom: 20.0),
+            child: GestureDetector(
+              onTap: () => FocusScope.of(context).unfocus(),
+              child: SingleChildScrollView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                child: Column(children: [
+                  _userInfoSection(),
+                  const Space(height: 200.0),
+                  _modifyButton(context)
+                ]),
+              ),
+            ),
+          );
+        }
       ),
     );
   }
@@ -47,7 +56,7 @@ class ModifyUserInfoView extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        _setField('닉네임', "닉네임은 10자 이내로 설정 가능합니다.", _nickNameController),
+        _nicknameField(),
         _setField('휴대폰 번호', "'010-0000-0000' 형식으로 입력해주세요", _phoneNumController),
         _setField('주소', "'OO시 OO구' 형식으로 입력해주세요", _addressController),
       ],
@@ -75,44 +84,127 @@ class ModifyUserInfoView extends StatelessWidget {
     );
   }
 
+  Widget _nicknameField() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Space(height: 25.0),
+        const B18Text(text: "닉네임"),
+        const Space(height: 10.0),
+        Row(mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            _setNicknameField(),
+            _checkNicknameBtn(_nickNameController.value.text)
+          ]
+        )
+      ]
+    );
+  }
+
+  Widget _setNicknameField() {
+    return SizedBox(
+      height: 70.0,
+      width: 220,
+      child: TextField(
+        decoration: _inputDecoration("닉네임은 10자 이내로 설정 가능합니다."),
+        textAlignVertical: TextAlignVertical.center,
+        controller: _nickNameController,
+        keyboardType: TextInputType.text,
+        onChanged: (value) {
+          Provider.of<ModifyUserInfoViewModel>(_context, listen: false).setNicknameAvailable(false, value);
+        },
+      ),
+    );
+  }
+
+  Widget _checkNicknameBtn(String nickname) {
+    bool isNicknameAvailable = Provider.of<ModifyUserInfoViewModel>(_context).isNicknameAvailable;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 23),
+      child: GestureDetector(
+        onTap: () => _validNickname(nickname),
+        child: Container(
+          alignment: Alignment.center,
+          width: 90,
+          height: 47,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(10),
+            color: isNicknameAvailable ? green : white,
+            border: Border.all(color: green, width: 2)
+          ),
+          child: R16Text(
+            text: isNicknameAvailable ? "확인 완료" : "중복 확인",
+            textColor: isNicknameAvailable ? white : green)
+        ),
+      ),
+    );
+  }
+
+  _validNickname(String nickname) async {
+    if(nickname.isNotEmpty) {
+      bool result = await Provider.of<UserProvider>(_context, listen: false).checkNicknameUsable(nickname);
+      if (result) {
+        Provider.of<ModifyUserInfoViewModel>(_context, listen: false).setNicknameAvailable(true, nickname);
+      } else {
+        _showWarningSnackBar("다른 닉네임을 사용해주세요!");
+      }
+    }
+  }
+
   Widget _modifyButton(BuildContext context) {
-    final scaffoldMessenger = ScaffoldMessenger.of(context);
-    final navigator = Navigator.of(context);
-    User user = UserProvider.user;
+    String phoneNumber =  _phoneNumController.value.text;
+    String address = _addressController.value.text;
+    bool isNicknameAvailable = Provider.of<ModifyUserInfoViewModel>(_context).isNicknameAvailable;
 
     return Container(
       alignment: Alignment.bottomCenter,
       child: LongCircledBtn(
         text: '수정하기',
         backgroundColor: navy,
-        onTap: () async {
-          UserParams userParams = UserParams(
-              signInPlatform: user.signInPlatform!,
-              userName: user.userName!,
-              userEmail: user.userEmail!,
-              userNickname: _nickNameController.value.text,
-              userPhoneNum: _phoneNumController.value.text,
-              userAddress: _addressController.value.text);
-
-          bool success = await Provider.of<UserProvider>(context, listen: false)
-              .modifyUser(user.userId!, userParams);
-
-          if (success) {
-            scaffoldMessenger.showSnackBar(const SnackBar(
-              duration: Duration(seconds: 1),
-              content: R16Text(text: '수정이 완료되었습니다 :D', textColor: white),
-            ));
-            navigator.pop();
+        onTap: () {
+          if (!isNicknameAvailable) {
+            _showWarningSnackBar("닉네임 중복확인을 해주세요!");
+          } else if (phoneNumber.isEmpty) {
+            _showWarningSnackBar("핸드폰 번호를 입력해주세요!");
+          } else if (address.isEmpty) {
+            _showWarningSnackBar("주소를 입력해주세요!");
           } else {
-            scaffoldMessenger.showSnackBar(const SnackBar(
-              duration: Duration(seconds: 1),
-              content: R16Text(
-                  text: '수정에 실패했습니다. 잠시 후 다시 시도해주세요.', textColor: white),
-            ));
+            _modifyUserInfo();
           }
-        },
-      ),
+        }
+      )
     );
+  }
+
+  _modifyUserInfo() async {
+    final scaffoldMessenger = ScaffoldMessenger.of(_context);
+    final navigator = Navigator.of(_context);
+    User user = UserProvider.user;
+
+    UserParams userParams = UserParams(
+        signInPlatform: user.signInPlatform!,
+        userName: user.userName!,
+        userEmail: user.userEmail!,
+        userNickname: _nickNameController.value.text,
+        userPhoneNum: _phoneNumController.value.text,
+        userAddress: _addressController.value.text);
+
+    bool success = await Provider.of<UserProvider>(_context, listen: false)
+        .modifyUser(user.userId!, userParams);
+
+    if (success) {
+      scaffoldMessenger.showSnackBar(const SnackBar(
+        duration: Duration(seconds: 1),
+        content: R16Text(text: '수정이 완료되었습니다 :D', textColor: white),
+      ));
+      navigator.pop();
+    } else {
+      scaffoldMessenger.showSnackBar(const SnackBar(
+        duration: Duration(seconds: 1),
+        content: R16Text(
+            text: '수정에 실패했습니다. 잠시 후 다시 시도해주세요.', textColor: white),
+      ));
+    }
   }
 
   InputDecoration _inputDecoration(String? helperText) {
@@ -132,5 +224,12 @@ class ModifyUserInfoView extends StatelessWidget {
           borderRadius: BorderRadius.all(Radius.circular(10.0)),
         ),
         contentPadding: const EdgeInsets.only(left: 10.0));
+  }
+
+  _showWarningSnackBar(String snackBarText) {
+    ScaffoldMessenger.of(_context).showSnackBar(SnackBar(
+      duration: const Duration(seconds: 1),
+      content: R16Text(text: snackBarText, textColor: white),
+    ));
   }
 }

--- a/lib/src/screens/tab5_mypage/account_management/setting_user_info/modify_user_info_view_model.dart
+++ b/lib/src/screens/tab5_mypage/account_management/setting_user_info/modify_user_info_view_model.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:navada_mobile_app/src/models/user/user_provider.dart';
+
+class ModifyUserInfoViewModel extends ChangeNotifier {
+  bool isNicknameAvailable = true;
+
+  setNicknameAvailable(bool val, String newNickname) {
+    if(newNickname == UserProvider.user.userNickname) {
+      isNicknameAvailable = true;
+    } else {
+      isNicknameAvailable = val;
+    }
+    notifyListeners();
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import shared_preferences_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }


### PR DESCRIPTION
사용자 정보 수정 화면에 닉네임 중복 확인 기능을 추가했습니다.

+) 구현하면서 닉네임이나 폰번호, 주소가 비어있을 시에 수정 api를 호출할 수 없도록 하는 게 좋을 것 같아서 
스낵바 보여주는 기능도 추가했습니다!

+) 폰번호가 모바일에서 화면에 나올 때 다 -가 넣어져서 나와야 되는 것 같아 모바일에서 로그인시 유저정보 저장할 때 -가 넣어져서 저장되도록 변경했는데, 이렇게 하면 안될 것 같으면 알려주시면 감사하겠습니다!!
기존 화면
<img width="256" alt="image" src="https://user-images.githubusercontent.com/51855129/218394596-963765ce-0af6-495c-8431-25e6ea7739a1.png">